### PR TITLE
Add PHP ^8.0 to the list of allowed versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2 || ^8.0",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^6.0 || ^7.0",
         "league/oauth1-client": "^1.5"


### PR DESCRIPTION
Oh, sorry to bug again @stevenmaguire, but I entirely forgot about another important change to the version constraints.

Can we merge this as well (considering that CI checks test for 8.0 already)?